### PR TITLE
Added new public api's for canPopPage, getTotalPageCount and scrollControlDisabledMaxHeightRatio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.0
+- Expose new api for canPopPage and getTotalPageCount
+- Expose scrollControlDisabledMaxHeightRatio in show and showMaterialDefault method
+- Added new example content demonstrating support for scrollable content in the modal and improve support scrollable content. [#7](https://github.com/danielkiing3/family_bottom_sheet/pull/7) by [MrLepage](https://github.com/MrLepage)
+- Fix No named parameter with the name 'requestFocus' for lower flutter version
+
 ## 0.0.2
 
 - Added a demo GIF to the `README.md` for visual demonstration of the bottom sheet

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ This package is inspired by the Family app's bottom sheet design system — wher
 
 This package is also inspired by work by the Wolt team on wolt_modal_sheet package
 
+# Contributors
+- [Aurélien Lepage](https://github.com/MrLepage)
+
 ## Contributing
 If you have a suggestion that would make this better, please fork the repo and create a pull request. You can also simply open an issue with the tag "enhancement". Don't forget to give the project a star! Thanks again!
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ This design gives you full control while following a clean, opinionated API simi
 - `showDragHandle`- Optionally display a drag handle at the top of the sheet.
 - `isDismissible`- Whether tapping outside the sheet dismisses it.
 - `isScrollControlled`- Expand the sheet beyond its default max height (good for full-screen sheets).
+-  `scrollControlDisabledMaxHeightRatio`- When `isScrollControlled` is false, this ratio determines the maximum height the sheet can occupy relative to the screen height
 - `useSafeArea`- Whether to automatically apply safe area insets to the outer sheet.
 - `useRootNavigator`- Whether to push the sheet to the root navigator.
 - `routeSettings`- Optional route metadata.

--- a/README.md
+++ b/README.md
@@ -63,8 +63,21 @@ FamilyModalSheet.of(context).pushPage(AnotherCustomPage());
 ```dart
 FamilyModalSheet.of(context).popPage();
 ```
-
 Note: If it's the last page in the sheet stack, calling popPage() will automatically close the entire bottom sheet.
+
+
+## Check if you can pop
+```dart
+final bool canPop = FamilyModalSheet.of(context).canPopPage();
+```
+Use this to determine if calling `popPage()` will pop a page or dismiss the entire sheet
+
+## Get total page count
+```dart
+final int pageCount = FamilyModalSheet.of(context).getTotalPageCount();
+```
+Returns the number of pages currently in the stack
+
 
 
 # Customization

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -130,10 +130,12 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
+  /// Example working with scrollable child
   Future<void> openChooseEmojiModal(BuildContext context) async {
     await FamilyModalSheet.show<void>(
       context: context,
       constraints: const BoxConstraints(maxHeight: 415),
+      // Use scrollControlDisabledMaxHeightRatio to control the content max height
       safeAreaMinimum: const EdgeInsets.only(bottom: 16),
       contentBackgroundColor: context.colors.surface,
       builder: (ctx) {

--- a/example/lib/presentation/widgets/choose_emoji/choose_emoji_content.dart
+++ b/example/lib/presentation/widgets/choose_emoji/choose_emoji_content.dart
@@ -48,9 +48,11 @@ class _ChooseEmojiContentState extends State<ChooseEmojiContent> {
                 final emoji = _filteredEmojis[index];
 
                 return OnTapScaler(
-                  onTap: () => FamilyModalSheet.of(context).pushPage(
-                    EmojiChoiceContent(emoji: emoji),
-                  ),
+                  onTap: () {
+                    FamilyModalSheet.of(context).pushPage(
+                      EmojiChoiceContent(emoji: emoji),
+                    );
+                  },
                   child: Center(
                     child: FittedBox(
                       fit: BoxFit.contain,

--- a/lib/src/family_modal_sheet.dart
+++ b/lib/src/family_modal_sheet.dart
@@ -25,8 +25,7 @@ class FamilyModalSheet<T> extends StatefulWidget {
     this.clipBehavior,
     this.constraints,
     this.isScrollControlled = false,
-    this.scrollControlDisabledMaxHeightRatio =
-        _defaultScrollControlDisabledMaxHeightRatio,
+    required this.scrollControlDisabledMaxHeightRatio,
     this.enableDrag = true,
     this.showDragHandle = false,
     this.safeAreaMinimum,
@@ -145,6 +144,8 @@ class FamilyModalSheet<T> extends StatefulWidget {
   /// - `clipBehavior`: Clip behavior for the sheet.
   /// - `constraints`: Constraints for the sheet's size.
   /// - `isScrollControlled`: Whether the sheet can take up the full height of the screen.
+  /// - `scrollControlDisabledMaxHeightRatio`: When `isScrollControlled` is false,
+  /// this ratio determines the maximum height the sheet can occupy relative to the screen height. Defaults to `$_defaultScrollControlDisabledMaxHeightRatio`.
   /// - `useRootNavigator`: Whether to push the sheet using the root navigator.
   /// - `isDismissible`: Whether tapping outside dismisses the sheet.
   /// - `enableDrag`: Whether the sheet can be dismissed by dragging down.
@@ -183,6 +184,8 @@ class FamilyModalSheet<T> extends StatefulWidget {
     Color? barrierColor,
     BoxConstraints? constraints,
     bool isScrollControlled = false,
+    double scrollControlDisabledMaxHeightRatio =
+        _defaultScrollControlDisabledMaxHeightRatio,
     bool useRootNavigator = false,
     bool isDismissible = true,
     bool enableDrag = true,
@@ -207,6 +210,8 @@ class FamilyModalSheet<T> extends StatefulWidget {
       FamilyBottomSheetRoute<T>(
         builder: builder,
         isScrollControlled: isScrollControlled,
+        scrollControlDisabledMaxHeightRatioValue:
+            scrollControlDisabledMaxHeightRatio,
         contentBackgroundColor: contentBackgroundColor,
         capturedThemes: InheritedTheme.capture(
           from: context,
@@ -286,6 +291,8 @@ class FamilyModalSheet<T> extends StatefulWidget {
     Color? barrierColor,
     BoxConstraints? constraints,
     bool isScrollControlled = false,
+    double scrollControlDisabledMaxHeightRatio =
+        _defaultScrollControlDisabledMaxHeightRatio,
     bool useRootNavigator = false,
     bool isDismissible = true,
     bool enableDrag = true,
@@ -310,6 +317,8 @@ class FamilyModalSheet<T> extends StatefulWidget {
       FamilyBottomSheetRoute<T>(
         builder: builder,
         isScrollControlled: isScrollControlled,
+        scrollControlDisabledMaxHeightRatioValue:
+            scrollControlDisabledMaxHeightRatio,
         contentBackgroundColor: contentBackgroundColor,
         capturedThemes: InheritedTheme.capture(
           from: context,

--- a/lib/src/family_modal_sheet.dart
+++ b/lib/src/family_modal_sheet.dart
@@ -507,6 +507,13 @@ class FamilyModalSheetState extends State<FamilyModalSheet> {
       Navigator.of(context).pop();
     }
   }
+
+  /// Returns true if there is more than one page in the stack,
+  /// meaning popPage() will pop a page instead of dismissing the sheet.
+  bool canPopPage() => _pages.length > 1;
+
+  /// Returns the number of page in the navigaion stack
+  int getTotalPageCount() => _pages.length;
 }
 
 /// Copied from the Flutter framework

--- a/lib/src/widgets/family_bottom_sheet_route.dart
+++ b/lib/src/widgets/family_bottom_sheet_route.dart
@@ -16,6 +16,7 @@ class FamilyBottomSheetRoute<T> extends ModalBottomSheetRoute<T> {
   FamilyBottomSheetRoute({
     required super.builder,
     required super.isScrollControlled,
+    required this.scrollControlDisabledMaxHeightRatioValue,
     required this.contentBackgroundColor,
     super.capturedThemes,
     super.barrierOnTapHint,
@@ -66,6 +67,8 @@ class FamilyBottomSheetRoute<T> extends ModalBottomSheetRoute<T> {
   ///
   /// Defines how content transitions are animated.
   final AnimationStyle? mainContentAnimationStyle;
+
+  final double scrollControlDisabledMaxHeightRatioValue;
 
   final ValueNotifier<EdgeInsets> _clipInsetssNotifier =
       ValueNotifier<EdgeInsets>(EdgeInsets.zero);
@@ -121,6 +124,8 @@ class FamilyBottomSheetRoute<T> extends ModalBottomSheetRoute<T> {
         route: this,
         builder: builder,
         isScrollControlled: isScrollControlled,
+        scrollControlDisabledMaxHeightRatio:
+            scrollControlDisabledMaxHeightRatioValue,
         backgroundColor: backgroundColor ??
             sheetTheme.modalBackgroundColor ??
             sheetTheme.backgroundColor,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,8 @@
 name: family_bottom_sheet
 description: A package for building smooth, customizable multi-page bottom sheets with seamless transitions — just like a Navigator, but inside a bottom sheet.
-version: 0.0.2
+version: 0.1.0
 repository: https://github.com/danielkiing3/family_bottom_sheet
+issue_tracker: https://github.com/danielkiing3/family_bottom_sheet/issues
 
 topics:
   - ui


### PR DESCRIPTION
## Description
- Expose new api for `canPopPage` and `getTotalPageCount`
-  Expose scrollControlDisabledMaxHeightRatio in `show` and `showMaterialDefault` method
- Improvement on docs
- Bumped version and updated CHANGELOG

## Related Issues
- Resolves #6 
- Resolves #4 
- Fixes #8 
- Fixes #5 
- Fixes #2 

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (Please specify):

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [] My PR includes tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/danielkiing3/family_bottom_sheet/blob/main/pubspec.yaml#L3)

<!-- Links -->
[Contributor Guide]: https://github.com/danielkiing3/family_bottom_sheet/blob/main/CONTRIBUTING.md